### PR TITLE
update to 1.5.3 AMI with sync to genesis false

### DIFF
--- a/templates/casper-node.yml
+++ b/templates/casper-node.yml
@@ -29,8 +29,8 @@ Parameters:
 
   AmiId:
     Type: String
-    Default: "ami-05efb53a3cc5b13ad"
-    Description: casper-node 1.4.15 AMI
+    Default: "ami-0a4a632cc2d842d2d"
+    Description: casper-node 1.5.3 AMI
 
   KeyName:
     Type: String


### PR DESCRIPTION
-  make Quickstart use the published 1.5.3 Marketplace AMI (/w sync_to_genesis=false)