### PR TITLE
use AMI 1.5.6 with sync_handler config change

### DIFF
--- a/templates/casper-node.yml
+++ b/templates/casper-node.yml
@@ -30,7 +30,7 @@ Parameters:
   AmiId:
     Type: String
     Default: "ami-0e295be39f75e82cf"
-    Description: casper-node 1.5.3 AMI
+    Description: casper-node 1.5.6 AMI
 
   KeyName:
     Type: String

--- a/templates/casper-node.yml
+++ b/templates/casper-node.yml
@@ -29,7 +29,7 @@ Parameters:
 
   AmiId:
     Type: String
-    Default: "ami-0a4a632cc2d842d2d"
+    Default: "ami-0e295be39f75e82cf"
     Description: casper-node 1.5.3 AMI
 
   KeyName:


### PR DESCRIPTION
- Quickstart uses latest 1.5.6 AMI with sync_handler config change