### PR TITLE
Update README.md to fix the Discord url

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,7 @@ These keys should be backed up by the node operator and stored in a secure locat
 
 ## Support
 
-[Support Portal](https://support.casperlabs.io)
-
-[Casper Discord](https://discord.gg/casperblockchain)
+[Casper Discord](https://discord.gg/caspernetwork)
 
 
 


### PR DESCRIPTION
- The new official url is https://discord.gg/caspernetwork
- Also remove the link to the support platform which doesn't exist anymore